### PR TITLE
Token separate from asset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,8 @@ import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
 import WorldFromTokenId from "./components/World/WorldFromTokenId";
 
 const subgraphUri =
-  "https://api.thegraph.com/subgraphs/name/lpscrypt/waypointrinkeby"
-  // "http://localhost:8000/subgraphs/name/scaffold-eth/your-contract";
+  "https://api.thegraph.com/subgraphs/name/lpscrypt/waypointrinkeby";
+// "http://localhost:8000/subgraphs/name/scaffold-eth/your-contract";
 
 const client = new ApolloClient({
   uri: subgraphUri,

--- a/src/api/ipfsLoader.ts
+++ b/src/api/ipfsLoader.ts
@@ -131,6 +131,7 @@ const loadSceneFromIpfs = async (
   return {
     scene,
     files: localFiles,
+    cid,
   };
 };
 

--- a/src/api/ipfsSaver.ts
+++ b/src/api/ipfsSaver.ts
@@ -1,6 +1,10 @@
+import { CIDString } from "web3.storage";
 import { SceneConfiguration, StoredSceneAndFiles } from "../types/scene";
 import { SceneFilesLocal } from "../types/shared";
-import { extractFilesToUploadAndLocations } from "./sceneParser";
+import {
+  extractFilesToUploadAndLocations,
+  filterUndefined,
+} from "./sceneParser";
 import { makeWeb3StorageClient } from "./web3Storage";
 
 export const metadataFileName = "metadata.json";
@@ -34,13 +38,13 @@ export const createJsonFileFromObject = (object: Object, fileName: string) => {
 export const makeIpfsSceneFiles = async ({
   scene,
   files,
-  tokenId,
   forkedFrom,
+  sceneImage,
 }: {
   scene: SceneConfiguration;
   files: SceneFilesLocal;
-  tokenId?: string;
   forkedFrom?: string;
+  sceneImage?: File;
 }) => {
   const { fileLocations: storedFileLocations, toUpload } =
     extractFilesToUploadAndLocations({ scene, files });
@@ -62,24 +66,46 @@ export const makeIpfsSceneFiles = async ({
   };
 };
 
+const toFileInIpfsFolder = (cid: CIDString, file: File | undefined) => {
+  if (!file) return undefined;
+
+  return `ipfs://${cid}/${file.name}`;
+};
+
 export const saveSceneToIpfs = async ({
   scene,
   files,
+  sceneImage,
   forkedFrom,
 }: {
   scene: SceneConfiguration;
   files: SceneFilesLocal;
+  sceneImage?: File;
   forkedFrom?: string;
 }) => {
   const { sceneConfigMetadata, sceneAssetsToUpload } = await makeIpfsSceneFiles(
     { scene, files, forkedFrom }
   );
 
-  const allFiles = [sceneConfigMetadata, ...sceneAssetsToUpload];
+  const allFiles = filterUndefined([
+    sceneConfigMetadata,
+    ...sceneAssetsToUpload,
+    sceneImage,
+  ]);
 
   const client = makeWeb3StorageClient();
 
   const cid = await client.put(allFiles);
 
-  return cid;
+  const sceneGraphFileUrl = toFileInIpfsFolder(
+    cid,
+    sceneConfigMetadata
+  ) as string;
+  const sceneImageUrl = toFileInIpfsFolder(cid, sceneImage);
+
+  return {
+    cid,
+    sceneGraphFileUrl,
+    sceneImageUrl: sceneImageUrl,
+  };
 };

--- a/src/api/ipfsSaver.ts
+++ b/src/api/ipfsSaver.ts
@@ -34,9 +34,13 @@ export const createJsonFileFromObject = (object: Object, fileName: string) => {
 export const makeIpfsSceneFiles = async ({
   scene,
   files,
+  tokenId,
+  forkedFrom,
 }: {
   scene: SceneConfiguration;
   files: SceneFilesLocal;
+  tokenId?: string;
+  forkedFrom?: string;
 }) => {
   const { fileLocations: storedFileLocations, toUpload } =
     extractFilesToUploadAndLocations({ scene, files });
@@ -44,6 +48,7 @@ export const makeIpfsSceneFiles = async ({
   const storedSceneAndFiles: StoredSceneAndFiles = {
     scene,
     files: storedFileLocations,
+    forkedFrom,
   };
 
   const sceneConfigMetadata = createJsonFileFromObject(
@@ -60,12 +65,14 @@ export const makeIpfsSceneFiles = async ({
 export const saveSceneToIpfs = async ({
   scene,
   files,
+  forkedFrom,
 }: {
   scene: SceneConfiguration;
   files: SceneFilesLocal;
+  forkedFrom?: string;
 }) => {
   const { sceneConfigMetadata, sceneAssetsToUpload } = await makeIpfsSceneFiles(
-    { scene, files }
+    { scene, files, forkedFrom }
   );
 
   const allFiles = [sceneConfigMetadata, ...sceneAssetsToUpload];

--- a/src/api/worldsQueries.ts
+++ b/src/api/worldsQueries.ts
@@ -26,13 +26,7 @@ export const useErc721TokenForFileUrl = (fileUrl: string | undefined) => {
 
         const fileContents = JSON.parse(fileContentsText) as WorldErc721;
 
-        // hack - get cid from url:
-        const urlSplit = tokenUrl.split("/");
-        const cid = urlSplit[urlSplit.length - 2];
-
-        const withPathsFixed = appendIpfsPathToContents(fileContents, cid);
-
-        setErc721Token(withPathsFixed);
+        setErc721Token(fileContents);
       } finally {
         setLoading(false);
       }

--- a/src/components/World/Builder/hooks/useBuilder.ts
+++ b/src/components/World/Builder/hooks/useBuilder.ts
@@ -73,6 +73,7 @@ export const useBuilder = ({
   const { updateWorld, status: mintWorldStatus } = useWorldTokenUpdater({
     sceneAndFiles: updatedSceneWithFiles,
     captureScreenshotFn: captureScreenshotFn?.fn,
+    existingSceneCid: sceneAndFiles.cid,
   });
   const { createWorld, status: createWorldStatus } = useWorldTokenCreator();
 

--- a/src/components/World/Builder/hooks/useBuilder.ts
+++ b/src/components/World/Builder/hooks/useBuilder.ts
@@ -80,6 +80,7 @@ export const useBuilder = ({
     {
       ...updatedSceneWithFiles,
       updateCount,
+      forkedFrom: sceneAndFiles.cid,
     }
   );
 

--- a/src/components/World/Builder/hooks/useSaveToIpfs.ts
+++ b/src/components/World/Builder/hooks/useSaveToIpfs.ts
@@ -31,7 +31,7 @@ const useSaveToIpfs = ({
       saving: true,
     });
     try {
-      const cid = await saveSceneToIpfs({
+      const { cid } = await saveSceneToIpfs({
         scene: scene,
         files: files,
         forkedFrom,

--- a/src/components/World/Builder/hooks/useSaveToIpfs.ts
+++ b/src/components/World/Builder/hooks/useSaveToIpfs.ts
@@ -8,10 +8,12 @@ const useSaveToIpfs = ({
   scene,
   files,
   updateCount,
+  forkedFrom,
 }: {
   scene: SceneConfiguration;
   files: SceneFilesLocal;
   updateCount: number;
+  forkedFrom?: string;
 }) => {
   const [hasChangesToSave, setHasChangesToSave] = useState(false);
 
@@ -32,6 +34,7 @@ const useSaveToIpfs = ({
       const cid = await saveSceneToIpfs({
         scene: scene,
         files: files,
+        forkedFrom,
       });
 
       setSaveSceneStatus({
@@ -49,7 +52,7 @@ const useSaveToIpfs = ({
         error: e as Error,
       });
     }
-  }, [scene, saveSceneStatus.saving, files]);
+  }, [saveSceneStatus.saving, scene, files, forkedFrom]);
 
   return {
     handleSaveToIpfs,

--- a/src/components/World/Minter/useWorldMinter.ts
+++ b/src/components/World/Minter/useWorldMinter.ts
@@ -22,8 +22,10 @@ export type MintWorldStatus = {
   mintedWorld?: MintedWorld;
 };
 
-export const localContractAddress = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
-export const rinkebyContractAddress = "0x8f181e382dF37f4DAB729c1868D0A190A929D614";
+export const localContractAddress =
+  "0x5FbDB2315678afecb367f032d93F642f64180aa3";
+export const rinkebyContractAddress =
+  "0x8f181e382dF37f4DAB729c1868D0A190A929D614";
 
 const contractAddress = rinkebyContractAddress;
 

--- a/src/components/World/YourWorlds.tsx
+++ b/src/components/World/YourWorlds.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useAccount } from "wagmi";
 import { useHttpsUriForIpfs } from "../../api/ipfsUrls";
@@ -15,6 +16,11 @@ export const World = ({ world }: { world: WorldData }) => {
   const { erc721Token, loading } = useErc721TokenForFileUrl(world.uri);
 
   const imageUrl = useHttpsUriForIpfs(erc721Token?.image);
+
+  useEffect(() => {
+    if (world.id === '3')
+    console.log(world.uri, erc721Token, imageUrl, loading);
+  }, [world.uri, imageUrl, world.id, erc721Token, loading])
 
   return (
     <div className="max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700">

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -18,12 +18,11 @@ export type SceneConfiguration = {
 export type SceneAndFiles = {
   scene: SceneConfiguration;
   files: SceneFilesLocal;
+  cid?: string;
 };
 
 export type StoredSceneAndFiles = {
-  previousVersion?: {
-    cid?: string;
-  };
   scene: SceneConfiguration;
   files: SceneFilesStored;
+  forkedFrom?: string;
 };


### PR DESCRIPTION
Saving the erc721 token separately from the assets, since we need to reference the assets by full ipfs url for them to work in opensea.

Fixes #22 

We now see the metadata image.  However, when we try to load the interactive application nft in opensea we get an error about localstorage

<img width="1616" alt="Screen Shot 2022-07-23 at 12 36 11 PM" src="https://user-images.githubusercontent.com/891755/180620544-5ebd03d6-0515-4910-a465-b406ec3f376e.png">

New er721 token looks like:
{
"image": "ipfs://bafybeieh5ix5i5inggysbl3hejg7jatwjnncrolczgvkpl2xsw4vdnaflu/image.jpg",
"name": "my world",
"animation_url": "ipfs://QmSc3vonb6g9quEf32RE1ZXhU7q8Vr3Y6CPc4PFUTpkxKi/#/worlds/0",
"scene_graph_url": "ipfs://bafybeieh5ix5i5inggysbl3hejg7jatwjnncrolczgvkpl2xsw4vdnaflu/metadata.json"
}
